### PR TITLE
Adding filtering capability to guitar tabs page

### DIFF
--- a/components/filter.js
+++ b/components/filter.js
@@ -1,0 +1,30 @@
+/**
+ * Does a simple client side filtering of elements based on a
+ * text value. To implement, add a text box with an ID of "filter",
+ * add the class "searchable" to the table to be searched, and add
+ * data attribute of "data-search" to the table's rows to serve as
+ * a search index. Make sure the data is lower case so we can do a
+ * case-insensitve comparison.
+ */
+$(document).ready(function()
+{
+	// Create a style element where we'll input the CSS needed
+	// to filter the table
+	var searchStyle = $('<style/>');
+	$('body').append(searchStyle);
+	
+	// Watch the filter input on keyup and then filter the results
+	$('#filter').bind('keyup', function()
+	{
+		// Text box blank? Reset table to show all results
+		if ( ! this.value)
+		{
+			searchStyle.html('');
+			return;
+		}
+		
+		// Data is indexed via a data attribute, create a CSS
+		// selector to filter the table
+		searchStyle.html('.searchable tr:not([data-search*="' + this.value.toLowerCase() + '"]) { display: none; }');
+	});
+});

--- a/tabs/index.php
+++ b/tabs/index.php
@@ -2,6 +2,8 @@
 <html>
 	<head>
 		<script type="text/javascript" src="../components/ga.js"></script>
+		<script type="text/javascript" src="../components/jquery/jquery.min.js"></script>
+		<script type="text/javascript" src="../components/filter.js"></script>
 		<link href="../components/bootstrap/css/bootstrap.css" type="text/css" rel="stylesheet" />
 		<link href="../components/bootstrap/css/bootstrap-responsive.css" type="text/css" rel="stylesheet" />
 	</head>
@@ -15,14 +17,15 @@
 						  <li><a href="../">Home</a></li>
 						  <li class="active">Tabs</li>
 						</ul>
-						<table class="table table-striped table-bordered table-condensed">
+						<input type="text" id="filter" name="filter" placeholder="Filter"><br><br>
+						<table class="table table-striped table-bordered table-condensed searchable">
 							<tbody>
 							<?php
 							$directory = "";
 							$tabs = glob($directory . "*.txt");
 							foreach ($tabs as $file) {
 							?>
-							<tr>
+							<tr data-search="<?php echo strtolower($file)?>">
 								<td><a href="<?php echo $file; ?>"><?php echo $file; ?></a></td>
 							</tr>
 							<?php


### PR DESCRIPTION
Hey Emil, see what you think of this. The tabs page is getting rather long, so I added a simple filtering mechanism to type in a textbox and have it filter the table. I've attached a GIF of it in action so you can see without too much fuss. I've put the JS in a separate file so we can easily use it on the bass tabs page should that start getting long.

Hope you like it, let me know if you'd like any changes or just aren't interested, I understand if you might not have expected or wanted changes outside of tabs.

![emilssearch](https://f.cloud.github.com/assets/93695/1146619/3ba2fbf4-1e74-11e3-8413-d6787fe871f3.gif)
