### PR TITLE
Fix for tab names that have commas in them

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,5 +2,5 @@ Options +FollowSymLinks
 Options +Indexes
 RewriteEngine On
 RewriteBase /
-RewriteRule ^(tabs|bass)\/([A-Z0-9a-z\s\'\(\)]+)\.txt file.html
+RewriteRule ^(tabs|bass)\/([A-Z0-9a-z,\s\'\(\)]+)\.txt file.html
 RewriteRule ^(tabs|bass)\/$ file_index.html


### PR DESCRIPTION
.htaccess was not correctly rewriting tab names that had a comma in them (eg, "My Friend, My Friend") and would result in a 404 error.  This fix should work, however I have not actually tested it.  The actual error I'm encountering is:
```
Not Found

The requested URL /tabs/My Friend, My Friend.txt was not found on this server.

Additionally, a 404 Not Found error was encountered while trying to use an ErrorDocument to handle the request.
```